### PR TITLE
Remove bad piece of advice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Then, in [Node.js](http://nodejs.org/):
 
 ```js
 require('string.prototype.startswith');
-
-// On Windows and on Mac systems with default settings, case doesn’t matter,
-// which allows you to do this instead:
-require('String.prototype.startsWith');
 ```
 
 ## Notes


### PR DESCRIPTION
Don't encourage relying on case insensitivity on Mac/Windows, as it leads to unportable code, and no real benefits.